### PR TITLE
Update default.rb

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,8 @@
 include_recipe "nodejs::npm"
 include_recipe "mongodb"
 
+package 'git'
+
 git "/opt/strider" do
   repository "git://github.com/Strider-CD/strider.git"
   reference "master"


### PR DESCRIPTION
Added `package 'git'` so that Chef installs the appropriate git package for your environment before proceeding to attempt to clone repos.  This was required for a Debian install and likely many other Linux distros.
